### PR TITLE
Change default directory

### DIFF
--- a/sticky/Configuration/StickyConfiguration.swift
+++ b/sticky/Configuration/StickyConfiguration.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public let defaultFileExtension = ".json"
+fileprivate let defaultBundleId = "com.sticky"
 
 public struct StickyConfiguration {
     public let localDirectory: URL
@@ -10,15 +11,34 @@ public struct StickyConfiguration {
     public let async: Bool
     public let logStyle: StickyLogStyle
     public let rollbackToSchemaVersion: Int?
-    
-    public init(
-        localDirectory: URL = try!
-            FileManager.default.url(
-                for: .documentDirectory,
+    public static var defaultDirectory: URL? {
+        do {
+            // Using /Library/Application Support/ for app data files
+            // backed up by iCloud
+            // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html
+            var appSupport = try FileManager.default.url(
+                for: .applicationSupportDirectory,
                 in: .allDomainsMask,
                 appropriateFor: nil,
-                create: false
-            ),
+                create: true
+            )
+            // Create subdirectory for bundleId
+            appSupport = appSupport.appendingPathComponent(Bundle.main.bundleIdentifier ?? defaultBundleId, isDirectory: true)
+            if !FileManager.default.fileExists(atPath: appSupport.path) {
+                try FileManager.default.createDirectory(at: appSupport,
+                                     withIntermediateDirectories: false)
+            }
+            
+            return appSupport
+        }
+        catch {
+            stickyLog(error)
+        }
+        return nil
+    }
+    
+    public init(
+        localDirectory: URL = defaultDirectory!,
         preloadCache: Bool = true,
         fileExtensionName: String = defaultFileExtension,
         clearDirectory: Bool = false,

--- a/sticky/Configuration/StickyConfiguration.swift
+++ b/sticky/Configuration/StickyConfiguration.swift
@@ -11,7 +11,7 @@ public struct StickyConfiguration {
     public let async: Bool
     public let logStyle: StickyLogStyle
     public let rollbackToSchemaVersion: Int?
-    public static var defaultDirectory: URL? {
+    public static var defaultDirectory: URL! {
         do {
             // Using /Library/Application Support/ for app data files
             // backed up by iCloud
@@ -38,7 +38,7 @@ public struct StickyConfiguration {
     }
     
     public init(
-        localDirectory: URL = defaultDirectory!,
+        localDirectory: URL = defaultDirectory,
         preloadCache: Bool = true,
         fileExtensionName: String = defaultFileExtension,
         clearDirectory: Bool = false,


### PR DESCRIPTION
Change default directory from /Documents to /Library/Application Support per Apple guidelines: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html